### PR TITLE
Require Python >=3.10 because of sae-lens

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "litcoder"
 version = "0.0.1"
 description = "A library for neural encoding and assembly processing"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = {text = "MIT"}
 authors = [
     {name = "Taha Binhuraib, Ruimin Gao, Anya Ivanova"}


### PR DESCRIPTION
`uv` fails to satisfy dependencies for Python 3.9:
```
avaidya@rihanna:~/src/litcoder_core$ uv run ipython                                                             
  × No solution found when resolving dependencies for split (markers: python_full_version == '3.9.*'):
  ╰─▶ Because the requested Python version (>=3.9) does not satisfy Python>=3.10 and sae-lens>=5.0.0 depends on Python>=3.10,<4.0, we can conclude that sae-lens>=5.0.0 cannot be used.
      And because only the following versions of sae-lens are available:
          sae-lens<=5.0.0
[...]
          sae-lens==6.22.2
          sae-lens==6.22.3
      we can conclude that sae-lens>=5.0.0 cannot be used.
      And because your project depends on sae-lens>=5.0.0 and your project requires litcoder[dev], we can conclude that your project's requirements are unsatisfiable.

      hint: Pre-releases are available for `sae-lens` in the requested range (e.g., 6.0.0rc5), but pre-releases weren't enabled (try: `--prerelease=allow`)

      hint: The `requires-python` value (>=3.9) includes Python versions that are not supported by your dependencies (e.g., sae-lens>=5.0.0 only supports >=3.10, <4.0).
```
This PR removes support for Python 3.9 and requires 3.10 (following the README).